### PR TITLE
Move UART pins substitutions to  the esphome .yaml

### DIFF
--- a/examples/mr24hpb1.yaml
+++ b/examples/mr24hpb1.yaml
@@ -1,12 +1,15 @@
 substitutions:
   device_id: my-mr24hpb1-sensor
   device_name: My MR24HPB1 Sensor
-
+  uart_rx_pin: "9"
+  uart_tx_pin: "8"
+  
 esp32:
   board: esp32dev
   framework:
     type: arduino
 
+# Enable Home Assistant API
 api:
   encryption:
     key: "{{YOUR ENCRYPTION KEY}}"
@@ -17,6 +20,10 @@ ota:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
-
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: ${device_id}
+    password: "{{PASSWORD}}"
+    
 packages:
-  device_base: !include packages/mr24hpb1.yaml
+  device_base: !include external_components/mr24/packages/mr24hpb1.yaml


### PR DESCRIPTION
I would propose to move UART pins substitutions to  esphome .yaml because they may differ between devices / esp boards.