### PR TITLE
Move UART pins substitutions to the esphome .yaml

### DIFF
--- a/examples/mr24hpb1.yaml
+++ b/examples/mr24hpb1.yaml
@@ -9,6 +9,7 @@ esp32:
   framework:
     type: arduino
 
+# Enable Home Assistant API
 api:
   encryption:
     key: "{{YOUR ENCRYPTION KEY}}"

--- a/examples/mr24hpb1.yaml
+++ b/examples/mr24hpb1.yaml
@@ -1,7 +1,9 @@
 substitutions:
   device_id: my-mr24hpb1-sensor
   device_name: My MR24HPB1 Sensor
-
+  uart_rx_pin: "9"
+  uart_tx_pin: "8"
+  
 esp32:
   board: esp32dev
   framework:
@@ -17,6 +19,10 @@ ota:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
-
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: ${device_id}
+    password: "{{PASSWORD}}"
+    
 packages:
-  device_base: !include packages/mr24hpb1.yaml
+  device_base: !include external_components/mr24/packages/mr24hpb1.yaml

--- a/examples/mr24hpc1.yaml
+++ b/examples/mr24hpc1.yaml
@@ -1,12 +1,15 @@
 substitutions:
   device_id: my-mr24hpc1-sensor
   device_name: My MR24HPC1 Sensor
-
+  uart_rx_pin: "9"
+  uart_tx_pin: "8"
+  
 esp32:
   board: esp32dev
   framework:
     type: arduino
 
+# Enable Home Assistant API
 api:
   encryption:
     key: "{{YOUR ENCRYPTION KEY}}"
@@ -17,12 +20,10 @@ ota:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
-
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: ${device_id}
+    password: "{{PASSWORD}}"
+    
 packages:
-  device_base: !include packages/mr24hpc1.yaml
-
-# packages:
-#   remote_package:
-#     url: https://github.com/thefipster/esphome-mmwave-sensors
-#     ref: release
-#     files: [packages/mr24hpc1.yaml]
+  device_base: !include external_components/mr24/packages/mr24hpc1.yaml

--- a/examples/mr60bha1.yaml
+++ b/examples/mr60bha1.yaml
@@ -1,12 +1,15 @@
 substitutions:
   device_id: my-mr60bha1-sensor
   device_name: My MR60BHA1 Sensor
-
+  uart_rx_pin: "9"
+  uart_tx_pin: "8"
+  
 esp32:
   board: esp32dev
   framework:
     type: arduino
 
+# Enable Home Assistant API
 api:
   encryption:
     key: "{{YOUR ENCRYPTION KEY}}"
@@ -17,6 +20,10 @@ ota:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
-
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: ${device_id}
+    password: "{{PASSWORD}}"
+    
 packages:
-  device_base: !include packages/mr60bha1.yaml
+  device_base: !include external_components/mr24/packages/mr60bha1.yaml

--- a/packages/mr24hpb1.yaml
+++ b/packages/mr24hpb1.yaml
@@ -3,8 +3,6 @@ substitutions:
   device_name: Test mmWave MR24HPB1
   header_frame: headers/mr24hpb1_frame.h
   header_sensor: headers/mr24hpb1.h
-  uart_rx_pin: "16"
-  uart_tx_pin: "17"
 
 esphome:
   name: ${device_id}


### PR DESCRIPTION
I would propose to move UART pins substitutions to esphome .yaml because they may differ between devices / esp boards.

(https://github.com/thefipster/esphome-mmwave-sensors/pull/8)